### PR TITLE
Hotfix/90541 duplicate heartbeat interval check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
   "require": {
     "php": ">=8.0",
     "amphp/amp": "v2.6.*",
-    "amphp/socket": "v1.1.*",
+    "amphp/socket": "v1.2.*",
     "phpinnacle/buffer": "v1.2.*"
   },
   "require-dev": {
     "phpunit/phpunit": "v9.5.*",
-    "vimeo/psalm": "v4.13.*",
-    "phpstan/phpstan": "v1.2.*"
+    "vimeo/psalm": "v4.18.*",
+    "phpstan/phpstan": "v1.4.*"
   },
   "prefer-stable": true,
   "autoload": {
@@ -52,6 +52,9 @@
   },
   "config": {
     "sort-packages": true,
-    "optimize-autoloader": true
+    "optimize-autoloader": true,
+    "allow-plugins": {
+      "composer/package-versions-deprecated": false
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "v9.5.*",
-    "vimeo/psalm": "v4.18.*",
+    "vimeo/psalm": "v4.19.*",
     "phpstan/phpstan": "v1.4.*"
   },
   "prefer-stable": true,

--- a/examples/basic.php
+++ b/examples/basic.php
@@ -28,7 +28,7 @@ Loop::run(function () {
     }
 
     yield $channel->consume(function (Message $message, Channel $channel) {
-        echo $message->content() . \PHP_EOL;
+        echo $message->content . \PHP_EOL;
 
         yield $channel->ack($message);
     }, 'basic_queue');

--- a/examples/worker.php
+++ b/examples/worker.php
@@ -32,7 +32,7 @@ Loop::run(function () {
     echo '[*] Waiting for messages. To exit press CTRL+C', \PHP_EOL;
 
     $tag = yield $channel->consume(function (Message $message, Channel $channel) {
-        echo "[x] Received message: {$message->content()}.", \PHP_EOL;
+        echo "[x] Received message: {$message->content}.", \PHP_EOL;
 
         // Do some work - we generate password hashes with a high cost
         // sleep() gets interrupted by Ctrl+C so it's not very good for demos
@@ -43,12 +43,12 @@ Loop::run(function () {
             password_hash(random_bytes(255), PASSWORD_BCRYPT, ["cost" => 15]);
         }
 
-        echo "[x] Done ", $message->content(), \PHP_EOL;
+        echo "[x] Done ", $message->content, \PHP_EOL;
 
         try {
             yield $channel->ack($message);
 
-            echo "ACK SUCCESS:: {$message->content()}", \PHP_EOL;
+            echo "ACK SUCCESS:: {$message->content}", \PHP_EOL;
         } catch (\Throwable $error) {
 
             echo "ACK FAILED:: {$error->getMessage()}", \PHP_EOL;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,4 @@
 parameters:
 	checkMissingIterableValueType: false
 	checkGenericClassInNonGenericObjectType: false
-	ignoreErrors:
-		- '#Cannot cast mixed to int#'
+

--- a/src/Client.php
+++ b/src/Client.php
@@ -136,6 +136,8 @@ final class Client
 
                         $this->connection->write($buffer);
                         $this->connection->close();
+
+                        $this->disableConnectionMonitor();
                     }
                 );
 
@@ -161,6 +163,8 @@ final class Client
      */
     public function disconnect(int $code = 0, string $reason = ''): Promise
     {
+        $this->disableConnectionMonitor();
+
         return call(
             function () use ($code, $reason) {
                 if (\in_array($this->state, [self::STATE_NOT_CONNECTED, self::STATE_DISCONNECTING])) {
@@ -445,5 +449,14 @@ final class Client
         );
 
         return $deferred->promise();
+    }
+
+    private function disableConnectionMonitor(): void {
+        if($this->connectionMonitorWatcherId !== null) {
+
+            Loop::cancel($this->connectionMonitorWatcherId);
+
+            $this->connectionMonitorWatcherId = null;
+        }
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -91,7 +91,7 @@ final class Client
 
                 $this->state = self::STATE_CONNECTING;
 
-                $this->connection = new Connection($this->config->uri());
+                $this->connection = new Connection($this->config->uri(), fn() => $this->state = self::STATE_NOT_CONNECTED);
 
                 yield $this->connection->open(
                     $this->config->timeout,
@@ -310,9 +310,7 @@ final class Client
                 $this->properties->tune($maxChannel, $maxFrame);
 
                 if ($heartbeatInterval > 0) {
-                    $this->connection->heartbeat($heartbeatInterval, function (){
-                        $this->state = self::STATE_NOT_CONNECTED;
-                    });
+                    $this->connection->heartbeat($heartbeatInterval);
                 }
             }
         );

--- a/src/Client.php
+++ b/src/Client.php
@@ -287,7 +287,7 @@ final class Client
                 $heartbeatInterval = $this->config->heartbeat;
 
                 if ($heartbeatInterval !== 0) {
-                    $heartbeatInterval = \min($heartbeatInterval, $tune->heartbeat);
+                    $heartbeatInterval = \min($heartbeatInterval, $tune->heartbeat * 1000);
                 }
 
                 $maxChannel = \min($this->config->maxChannel, $tune->channelMax);
@@ -302,7 +302,7 @@ final class Client
                     ->appendUint16(31)
                     ->appendInt16($maxChannel)
                     ->appendInt32($maxFrame)
-                    ->appendInt16($heartbeatInterval)
+                    ->appendInt16((int) ($heartbeatInterval / 1000))
                     ->appendUint8(206);
 
                 yield $this->connection->write($buffer);

--- a/src/Client.php
+++ b/src/Client.php
@@ -255,7 +255,7 @@ final class Client
 
     public function isConnected(): bool
     {
-        return $this->state === self::STATE_CONNECTED;
+        return $this->state === self::STATE_CONNECTED && $this->connection->connected();
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace PHPinnacle\Ridge;
 
+use Amp\Loop;
 use function Amp\asyncCall;
 use function Amp\call;
 use Amp\Deferred;
@@ -23,6 +24,8 @@ final class Client
     private const STATE_CONNECTING = 1;
     private const STATE_CONNECTED = 2;
     private const STATE_DISCONNECTING = 3;
+
+    private const CONNECTION_MONITOR_INTERVAL = 5000;
 
     /**
      * @var Config
@@ -53,6 +56,11 @@ final class Client
      * @var Properties
      */
     private $properties;
+
+    /**
+     * @var string|null
+     */
+    private $connectionMonitorWatcherId;
 
     public function __construct(Config $config)
     {
@@ -91,7 +99,7 @@ final class Client
 
                 $this->state = self::STATE_CONNECTING;
 
-                $this->connection = new Connection($this->config->uri(), fn() => $this->state = self::STATE_NOT_CONNECTED);
+                $this->connection = new Connection($this->config->uri());
 
                 yield $this->connection->open(
                     $this->config->timeout,
@@ -132,6 +140,16 @@ final class Client
                 );
 
                 $this->state = self::STATE_CONNECTED;
+
+                $this->connectionMonitorWatcherId =  Loop::repeat(
+                    self::CONNECTION_MONITOR_INTERVAL,
+                    function(): void
+                    {
+                        if($this->connection->connected() === false) {
+                            throw Exception\ClientException::disconnected();
+                        }
+                    }
+                );
             }
         );
     }
@@ -151,6 +169,12 @@ final class Client
 
                 if ($this->state !== self::STATE_CONNECTED) {
                     throw Exception\ClientException::notConnected();
+                }
+
+                if($this->connectionMonitorWatcherId !== null){
+                    Loop::cancel($this->connectionMonitorWatcherId);
+
+                    $this->connectionMonitorWatcherId = null;
                 }
 
                 $this->state = self::STATE_DISCONNECTING;

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -26,6 +26,10 @@ final class ClientException extends RidgeException
         return new self('Client is not connected to server.');
     }
 
+    public static function disconnected(): self {
+        return new self('The client was unexpectedly disconnected from the server');
+    }
+
     public static function alreadyConnected(): self
     {
         return new self('Client is already connected/connecting.');

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -53,6 +53,8 @@ abstract class AsyncTest extends RidgeTest
 
                 $return = yield call([$this, $this->realTestName], ...$args);
 
+                yield $client->disconnect();
+
                 $info  = Loop::getInfo();
                 $count = $info['enabled_watchers']['referenced'];
 


### PR DESCRIPTION
fix duplicate check of passed time in heartbeat interval
The Amp\Loop is already calling the function in the right interval.
When the socket->write function call is scheduled in another timeframe as the call of the heartbeat function (due to the asynchronous calls), the next time the heartbeat function is called $currentTime is a little smaller than the value of $nextHeartbeat thereby no heartbeat is sent and in RabbitMQ the heartbeat is timed out and the connection closed although the client is still available.